### PR TITLE
fix: Fix type casting issues in examples for `-Dno_number_autocast` c…

### DIFF
--- a/examples/cubic_bezier.cr
+++ b/examples/cubic_bezier.cr
@@ -34,9 +34,9 @@ class CubicBezier < PF::Game
     if point = @selected_point
       point.value = cursor.to_f
       point.value.x = 0 if point.value.x < 0
-      point.value.x = window.width if point.value.x > window.width
+      point.value.x = window.width.to_f if point.value.x > window.width
       point.value.y = 0 if point.value.y < 0
-      point.value.y = window.height if point.value.y > window.height
+      point.value.y = window.height.to_f if point.value.y > window.height
     else
       @hover_point = @curve.point_pointers.find { |p| cursor.distance(p.value) < 4 }
     end

--- a/examples/draw_line.cr
+++ b/examples/draw_line.cr
@@ -41,7 +41,7 @@ class DrawLine < PF::Game
       end
 
       if v.pos.x > window.width
-        v.pos.x = window.width
+        v.pos.x = window.width.to_f
         v.vel.x = -v.vel.x
       end
 
@@ -51,7 +51,7 @@ class DrawLine < PF::Game
       end
 
       if v.pos.y > window.height
-        v.pos.y = window.height
+        v.pos.y = window.height.to_f
         v.vel.y = -v.vel.y
       end
     end

--- a/examples/piano.cr
+++ b/examples/piano.cr
@@ -66,7 +66,7 @@ class Piano < PF::Game
 
       @instruments.each do |instrument|
         instrument.sounds.each do |sound|
-          value += sound.sample(time)
+          value += sound.sample(time.to_f)
         end
       end
 


### PR DESCRIPTION
Fix following error when enable `-Dno_number_autocast`


```
 crystal build --release --no-debug --output "examples/build" --progress "examples/cubic_bezier.cr"

In examples/cubic_bezier.cr:37:30

 37 | point.value.x = window.width if point.value.x > window.width
                             ^----
Error: expected argument #1 to 'PF2d::Vec2(Float64)#x=' to be Float64, not Int32
```